### PR TITLE
Add key `YUNCHANG_MIGRAPHX_MODEL_EXPORT_DIR` to config export path of migraphx compiled model

### DIFF
--- a/wan/image2video.py
+++ b/wan/image2video.py
@@ -328,6 +328,8 @@ class WanI2V:
 
                 x0 = [latent.to(self.device)]
                 del latent_model_input, timestep
+                if self.rank == 0:
+                    print("")
 
             if offload_model:
                 self.model.cpu()

--- a/wan/modules/attention.py
+++ b/wan/modules/attention.py
@@ -1,5 +1,7 @@
 # Copyright 2024-2025 The Alibaba Wan Team Authors. All rights reserved.
 import torch
+import os
+import torch.distributed as dist
 
 try:
     import flash_attn_interface
@@ -130,6 +132,100 @@ def flash_attention(
     return x.type(out_dtype)
 
 
+class _torch_nn_functional_scaled_dot_product_attention_MIGraphX(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    def forward(self,
+        q, k, v,
+        attn_mask = None,
+        is_causal = False,
+        dropout_p = 0.0
+    ):
+        output = torch.nn.functional.scaled_dot_product_attention(
+            q.transpose(1, 2),
+            k.transpose(1, 2),
+            v.transpose(1, 2),
+            attn_mask=attn_mask,
+            is_causal=is_causal,
+            dropout_p=dropout_p
+        )
+        return output.transpose(1, 2)
+
+def torch_nn_functional_scaled_dot_product_attention_MIGraphX(hash_key, mgx_export_path = None):
+    options = {"deallocate": True}
+    if mgx_export_path != "":
+        if dist.is_initialized():
+            mgx_path = os.path.join(mgx_export_path, f"wan_attention.{hash_key}.rank_{dist.get_rank()}.mgx")
+        else:
+            mgx_path = os.path.join(mgx_export_path, f"wan_attention.{hash_key}.mgx")
+
+        if os.path.exists(mgx_path):
+            print(f"Load mgx model from : {mgx_path}")
+            options.update({ "load_compiled": mgx_path })
+        else:
+            print(f"Export mgx model to : {mgx_path}")
+            options.update({ "save_compiled": mgx_path })
+
+    import torch_migraphx
+    m = _torch_nn_functional_scaled_dot_product_attention_MIGraphX()
+    m = torch.compile(m, backend='migraphx', options=options, dynamic=False)
+
+    return m
+
+
+class TorchAttnImplPool:
+    def __init__(self):
+        self.cache = {}
+        self.key_type = os.environ["YUNCHANG_FLASH_ATTENTION_IMPL"] if "YUNCHANG_FLASH_ATTENTION_IMPL" in os.environ else "default"
+        self.mgx_export_path = os.environ["YUNCHANG_MIGRAPHX_MODEL_EXPORT_DIR"] if "YUNCHANG_MIGRAPHX_MODEL_EXPORT_DIR" in os.environ else ""
+        self.enable_finite_check = os.environ.get("YUNCHANG_ENABLE_FINITE_CHECK", "OFF") == "ON"
+        print(f"Using TorchAttnImplPool as : {self.key_type}, Finite check : {self.enable_finite_check}")
+
+    def use_specific_attention_impl(self):
+        return self.key_type != "default"
+
+    def compute_attention(
+        self, q, k, v,
+        attn_mask=None,
+        is_causal=False,
+        dropout_p=0.0
+    ):
+        key = (
+            q.shape, q.dtype, q.device,
+            k.shape, k.dtype,
+            v.shape, v.dtype,
+            attn_mask,
+            is_causal,
+            dropout_p
+        )
+        hash_key = hash(key)
+
+        if key not in self.cache:
+            if self.key_type == "torch.nn.functional.scaled_dot_product_attention+MIGraphX":
+                self.cache[key] = torch_nn_functional_scaled_dot_product_attention_MIGraphX(hash_key, self.mgx_export_path)
+            else:
+                raise ValueError(f"Unsupported key type: {self.key_type}")
+
+        m = self.cache[key]
+
+        output = m(
+            q, k, v,
+            attn_mask=attn_mask,
+            is_causal=is_causal,
+            dropout_p=dropout_p
+        )
+
+        if self.enable_finite_check:
+            if torch.isfinite(output).all().item():
+                return output
+            else:
+                return None
+        else:
+            return output
+
+attn_pool = TorchAttnImplPool()
+
 def attention(
     q,
     k,
@@ -145,35 +241,33 @@ def attention(
     dtype=torch.float16,
     fa_version=None,
 ):
-    if FLASH_ATTN_2_AVAILABLE or FLASH_ATTN_3_AVAILABLE:
-        return flash_attention(
-            q=q,
-            k=k,
-            v=v,
-            q_lens=q_lens,
-            k_lens=k_lens,
-            dropout_p=dropout_p,
-            softmax_scale=softmax_scale,
-            q_scale=q_scale,
-            causal=causal,
-            window_size=window_size,
-            deterministic=deterministic,
-            dtype=dtype,
-            version=fa_version,
+    # -----------------------------------------------------------------------------
+    # Use the TorchAttnImplPool to compute attention
+    if attn_pool.use_specific_attention_impl():
+        out = attn_pool.compute_attention(
+            q, k, v,
+            attn_mask=None, is_causal=causal, dropout_p=dropout_p
         )
-    else:
-        if q_lens is not None or k_lens is not None:
-            warnings.warn(
-                'Padding mask is disabled when using scaled_dot_product_attention. It can have a significant impact on performance.'
-            )
-        attn_mask = None
 
-        q = q.transpose(1, 2).to(dtype)
-        k = k.transpose(1, 2).to(dtype)
-        v = v.transpose(1, 2).to(dtype)
+        # out will be None if the original value contains a non-finite
+        # value when ENABLE_FINITE_CHECK is enabled.
+        # In this case, we will fall back to the original flash_attn path.
+        if out is not None:
+            return out
+    
 
-        out = torch.nn.functional.scaled_dot_product_attention(
-            q, k, v, attn_mask=attn_mask, is_causal=causal, dropout_p=dropout_p)
+    if q_lens is not None or k_lens is not None:
+        warnings.warn(
+            'Padding mask is disabled when using scaled_dot_product_attention. It can have a significant impact on performance.'
+        )
+    attn_mask = None
 
-        out = out.transpose(1, 2).contiguous()
-        return out
+    q = q.transpose(1, 2).to(dtype)
+    k = k.transpose(1, 2).to(dtype)
+    v = v.transpose(1, 2).to(dtype)
+
+    out = torch.nn.functional.scaled_dot_product_attention(
+        q, k, v, attn_mask=attn_mask, is_causal=causal, dropout_p=dropout_p)
+
+    out = out.transpose(1, 2).contiguous()
+    return out

--- a/wan/text2video.py
+++ b/wan/text2video.py
@@ -241,14 +241,10 @@ class WanT2V:
 
                 self.model.to(self.device)
 
-                import time
-                t0 = time.perf_counter()
                 noise_pred_cond = self.model(
                     latent_model_input, t=timestep, **arg_c)[0]
                 noise_pred_uncond = self.model(
                     latent_model_input, t=timestep, **arg_null)[0]
-                torch.cuda.synchronize()
-                print(f"inference time(s) = {time.perf_counter() - t0:.5f}")
 
                 noise_pred = noise_pred_uncond + guide_scale * (
                     noise_pred_cond - noise_pred_uncond)
@@ -260,6 +256,8 @@ class WanT2V:
                     return_dict=False,
                     generator=seed_g)[0]
                 latents = [temp_x0.squeeze(0)]
+                if self.rank == 0:
+                    print("")
 
             x0 = latents
             if offload_model:


### PR DESCRIPTION
Add key YUNCHANG_MIGRAPHX_MODEL_EXPORT_DIR to config export path of migraphx compiled model

Command:

    YUNCHANG_MIGRAPHX_MODEL_EXPORT_DIR="./" \
    YUNCHANG_FLASH_ATTENTION_IMPL="torch.nn.functional.scaled_dot_product_attention+MIGraphX"  \
    python test.py

           >> compiled file will save to: ./attention.390909371700163057.mgx